### PR TITLE
When there is no displayName property passport module crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,14 +259,14 @@ module.exports = {
           user.firstName += ' ' + profile.name.middleName;
         }
         user.lastName = profile.name.familyName;
+      } else if (profile.firstName || profile.lastName) {
+        user.firstName = profile.firstName;
+        user.lastName = profile.lastName;
       } else if (profile.displayName) {
         parsedName = humanname.parse(profile.displayName);
         user.firstName = parsedName.firstName;
         user.lastName = parsedName.lastName;
-      } else {
-        user.firstName = profile.firstName;
-        user.lastName = profile.lastName;
-      }
+      } 
       var req = self.apos.tasks.getReq();
       if (self.createGroup) {
         user.groupIds = [ self.createGroup._id ];

--- a/index.js
+++ b/index.js
@@ -259,10 +259,13 @@ module.exports = {
           user.firstName += ' ' + profile.name.middleName;
         }
         user.lastName = profile.name.familyName;
-      } else {
+      } else if (profile.displayName) {
         parsedName = humanname.parse(profile.displayName);
         user.firstName = parsedName.firstName;
         user.lastName = parsedName.lastName;
+      } else {
+        user.firstName = profile.firstName;
+        user.lastName = profile.lastName;
       }
       var req = self.apos.tasks.getReq();
       if (self.createGroup) {


### PR DESCRIPTION
When integrating the Keycloak passport module, there is no key for displayName when calling createUser. Added a check if displayName exists and set firstName/lastName keys directly (these are set in the Keycloak module)